### PR TITLE
Fix u64 result

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -309,7 +309,7 @@ int argmain(int argc, char **argv)
                             if (u64buf[i] == u64query && searchSize < SEARCH_ARR_SIZE)
                             {
                                 printf("Got a hit at %lx!\r\n", curaddr + i * sizeof(u64));
-                                searchArr[searchSize++] = curaddr + i * sizeof(u32);
+                                searchArr[searchSize++] = curaddr + i * sizeof(u64);
                             }
                         }
                     }


### PR DESCRIPTION
We are using wrongly `u32` instead of `u64`.